### PR TITLE
Fix some stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ For RSpec usage, add `require 'truenames/rspec'` to `spec/spec_helper.rb`.
 
 ## TODO
 
-* Make actual output more closely match README
 * Is formatting of ambiguous cases, especially inside lists, helpful?
   Would permutations be better? E.g.:
   "(a, b, c or d)" vs "(a, b, c) or (a, b, d)"

--- a/lib/truenames/matchers/expr_eq.rb
+++ b/lib/truenames/matchers/expr_eq.rb
@@ -20,8 +20,8 @@ module Truenames
       end
 
       def failure_message_for_should
-        "\nexpected: #{expected.inspect}#{inspect_references_for(expected)}\n" +
-          "     got: #{actual.inspect}#{inspect_references_for(actual)}\n\n(compared using ==)\n"
+        "\nexpected: #{inspect_references_for(expected)}\n" +
+          "     got: #{inspect_references_for(actual)}\n\n(compared using ==)\n"
       end
 
       private
@@ -30,9 +30,9 @@ module Truenames
         references = reference_names_for(value)
 
         if references.empty?
-          ''
+          value.inspect
         else
-          " (#{references})"
+          references
         end
       end
 

--- a/spec/truenames/matchers/expr_eq_spec.rb
+++ b/spec/truenames/matchers/expr_eq_spec.rb
@@ -93,4 +93,14 @@ describe Truenames::Matchers::ExprEq do
     matcher.matches?([c,d,e])
     matcher.failure_message_for_should.should eq "\nexpected: [z or a, b, c]\n     got: [c, d, e or f]\n\n(compared using ==)\n"
   end
+
+  context "with let statements" do
+    let(:hello) { "hello" }
+
+    it "displays references to let statements" do
+      matcher = expr_eq("goodbye")
+      matcher.matches?(hello)
+      matcher.failure_message_for_should.should eq "\nexpected: \"goodbye\"\n     got: let(:hello)\n\n(compared using ==)\n"
+    end
+  end
 end

--- a/spec/truenames/matchers/expr_eq_spec.rb
+++ b/spec/truenames/matchers/expr_eq_spec.rb
@@ -45,7 +45,7 @@ describe Truenames::Matchers::ExprEq do
 
     matcher = expr_eq(abc)
     matcher.matches?(bcd)
-    matcher.failure_message_for_should.should eq "\nexpected: 123 (abc)\n     got: 234 (bcd)\n\n(compared using ==)\n"
+    matcher.failure_message_for_should.should eq "\nexpected: abc\n     got: bcd\n\n(compared using ==)\n"
   end
 
   it "provides multiple local variable references when they exist" do
@@ -56,7 +56,7 @@ describe Truenames::Matchers::ExprEq do
 
     matcher = expr_eq(abc)
     matcher.matches?(bcd)
-    matcher.failure_message_for_should.should eq "\nexpected: 123 (zab or abc)\n     got: 234 (bcd or cde)\n\n(compared using ==)\n"
+    matcher.failure_message_for_should.should eq "\nexpected: zab or abc\n     got: bcd or cde\n\n(compared using ==)\n"
   end
 
   it "provides instance variable reference when available" do
@@ -65,7 +65,7 @@ describe Truenames::Matchers::ExprEq do
 
     matcher = expr_eq(@abc)
     matcher.matches?(@bcd)
-    matcher.failure_message_for_should.should eq "\nexpected: 123 (@abc)\n     got: 234 (@bcd)\n\n(compared using ==)\n"
+    matcher.failure_message_for_should.should eq "\nexpected: @abc\n     got: @bcd\n\n(compared using ==)\n"
   end
 
   it "provides local variable references inside arrays" do
@@ -77,7 +77,7 @@ describe Truenames::Matchers::ExprEq do
 
     matcher = expr_eq([a,b,c])
     matcher.matches?([c,d,e])
-    matcher.failure_message_for_should.should eq "\nexpected: [1, 2, 3] ([a, b, c])\n     got: [3, 4, 5] ([c, d, e])\n\n(compared using ==)\n"
+    matcher.failure_message_for_should.should eq "\nexpected: [a, b, c]\n     got: [c, d, e]\n\n(compared using ==)\n"
   end
 
   it "displays ambiguous matches inside arrays " do
@@ -91,6 +91,6 @@ describe Truenames::Matchers::ExprEq do
 
     matcher = expr_eq([a,b,c])
     matcher.matches?([c,d,e])
-    matcher.failure_message_for_should.should eq "\nexpected: [1, 2, 3] ([z or a, b, c])\n     got: [3, 4, 5] ([c, d, e or f])\n\n(compared using ==)\n"
+    matcher.failure_message_for_should.should eq "\nexpected: [z or a, b, c]\n     got: [c, d, e or f]\n\n(compared using ==)\n"
   end
 end

--- a/spec/truenames/matchers/expr_eq_spec.rb
+++ b/spec/truenames/matchers/expr_eq_spec.rb
@@ -103,4 +103,14 @@ describe Truenames::Matchers::ExprEq do
       matcher.failure_message_for_should.should eq "\nexpected: \"goodbye\"\n     got: let(:hello)\n\n(compared using ==)\n"
     end
   end
+
+  context "with let! statements" do
+    let!(:hello) { "hello" }
+
+    it "displays references to let! statements as let statements" do
+      matcher = expr_eq("goodbye")
+      matcher.matches?(hello)
+      matcher.failure_message_for_should.should eq "\nexpected: \"goodbye\"\n     got: let(:hello)\n\n(compared using ==)\n"
+    end
+  end
 end


### PR DESCRIPTION
- Display `let(:hello)` when value comes from a `let` block
- Update output to match the README
- Mooooorrrreee maaaaagiiiicc

I tried to get `let!(:hello)` to display in the output when you use a let-bang. I was able to get to calling the `let` hooks in `before` blocks before giving up:

``` ruby
def let_bang?(let_value)
  let_values = eval("self.class.hooks[:before][:each].map(&:call)", @binding)
end
```

I'm not sure it matters - I've never done let and let-bang for the same value before.
